### PR TITLE
Update ExceptionHandler.php

### DIFF
--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -11,7 +11,6 @@
 
 namespace NunoMaduro\Collision\Adapters\Laravel;
 
-use Exception;
 use Illuminate\Contracts\Foundation\Application;
 use NunoMaduro\Collision\Contracts\Provider as ProviderContract;
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
@@ -51,7 +50,7 @@ class ExceptionHandler implements ExceptionHandlerContract
         $this->app = $app;
         $this->appExceptionHandler = $appExceptionHandler;
     }
-    
+
     /**
      * Converts \Throwable to \Exception
      *
@@ -60,10 +59,10 @@ class ExceptionHandler implements ExceptionHandlerContract
      * @return \Exception
      */
     protected function convertThrowable($e)
-    {  
-       return ($e instanceof \Throwable) ? new Exception($e->getMessage(), $e->getCode(), $e) : $e;
+    {
+        return ($e instanceof \Throwable) ? new \Exception($e->getMessage(), $e->getCode(), $e) : $e;
     }
-    
+
 
     /**
      * {@inheritdoc}
@@ -91,7 +90,7 @@ class ExceptionHandler implements ExceptionHandlerContract
     public function renderForConsole($output, $e)
     {
         $e = $this->convertThrowable($e);
-        
+
         if ($e instanceof SymfonyConsoleExceptionInterface) {
             $this->appExceptionHandler->renderForConsole($output, $e);
         } else {

--- a/src/Adapters/Laravel/ExceptionHandler.php
+++ b/src/Adapters/Laravel/ExceptionHandler.php
@@ -51,28 +51,47 @@ class ExceptionHandler implements ExceptionHandlerContract
         $this->app = $app;
         $this->appExceptionHandler = $appExceptionHandler;
     }
+    
+    /**
+     * Converts \Throwable to \Exception
+     *
+     * @param  \Throwable|\Exception $e
+     *
+     * @return \Exception
+     */
+    protected function convertThrowable($e)
+    {  
+       return ($e instanceof \Throwable) ? new Exception($e->getMessage(), $e->getCode(), $e) : $e;
+    }
+    
 
     /**
      * {@inheritdoc}
      */
-    public function report(Exception $e)
+    public function report($e)
     {
-        $this->appExceptionHandler->report($e);
+        $this->appExceptionHandler->report(
+            $this->convertThrowable($e)
+        );
     }
 
     /**
      * {@inheritdoc}
      */
-    public function render($request, Exception $e)
+    public function render($request, $e)
     {
-        return $this->appExceptionHandler->render($request, $e);
+        return $this->appExceptionHandler->render(
+            $request, $this->convertThrowable($e)
+        );
     }
 
     /**
      * {@inheritdoc}
      */
-    public function renderForConsole($output, Exception $e)
+    public function renderForConsole($output, $e)
     {
+        $e = $this->convertThrowable($e);
+        
         if ($e instanceof SymfonyConsoleExceptionInterface) {
             $this->appExceptionHandler->renderForConsole($output, $e);
         } else {
@@ -93,8 +112,10 @@ class ExceptionHandler implements ExceptionHandlerContract
      * @param  \Exception  $e
      * @return bool
      */
-    public function shouldReport(Exception $e)
+    public function shouldReport($e)
     {
-        return $this->appExceptionHandler->shouldReport($e);
+        return $this->appExceptionHandler->shouldReport(
+            $this->convertThrowable($e)
+        );
     }
 }


### PR DESCRIPTION
Because, if you use Swoole, it can thorw \Throwable. If it throw Throwable we have big trace of errors and it is not clear what is happening.